### PR TITLE
Update token claims for compatibility

### DIFF
--- a/src/TokenBuilder.php
+++ b/src/TokenBuilder.php
@@ -44,8 +44,9 @@ final class TokenBuilder
             ->set('iss', $this->origin)
             ->set('aud', $audience)
             ->set('exp', time() + 60)
-            ->set('nonce', $nonce)
+            ->set('iat', time())
             ->set('email', $email)
+            ->set('nonce', $nonce)
             ->setHeader('kid', $this->kid)
             ->sign($this->signer, $this->key)
             ->getToken();


### PR DESCRIPTION
See: https://github.com/portier/portier-broker/pull/161

We could maybe do normalization, by querying the entry we also bind to, and looking for a specific (configurable) attribute containing the actual username. Something for later.

UPDATE: Since `email_original` is now optional, I removed it again. This PR still adds the necessary `iat` claim.